### PR TITLE
Made route to return the generated table for a host.

### DIFF
--- a/infoset/utils/jm_configuration.py
+++ b/infoset/utils/jm_configuration.py
@@ -192,7 +192,7 @@ class ConfigServer(object):
 
         """
         # Get parameter
-        value = ('%s/%s.yaml') % (self.snmp_directory(), host)
+        value = ('%s/%s.yaml') % (self.data_directory(), host)
 
         # Return
         return value

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ six>=1.10.0
 SQLAlchemy>=1.0.14
 Werkzeug>=0.11.10
 wrapt>=1.10.8
+matplotlib>=1.5.1

--- a/www/views.py
+++ b/www/views.py
@@ -27,6 +27,7 @@ from infoset.utils import ColorWheel
 from infoset.utils import jm_general
 from infoset.language import language
 from www import infoset
+from infoset.web import ws_device
 # Matplotlib imports, Do not edit order
 """
 import numpy as np
@@ -384,3 +385,23 @@ def fetch_graph_stacked(uid, datapoint):
     response = make_response(png_output.getvalue())
     response.headers['Content-Type'] = 'image/png'
     return response
+
+
+@infoset.route('/fetch/agent/<ip>/table', methods=["GET"])
+def fetch_table(ip):
+    config = infoset.config['GLOBAL_CONFIG']
+    ws_device.make(config, True)
+
+    try:
+
+        with open(path.join(config.web_directory(), ip + ".html")) as file:
+            html = file.read()
+            return html
+
+    except IOError as e:
+        print("Error occurred while retrieving table for " + ip + ": {0}".format(e))
+        return "Error occurred while retrieving table for " + ip + ": {0}".format(e)
+    except:
+        print("Unexpected error:", sys.exc_info()[0])
+        return "Unexpected error occurred."
+


### PR DESCRIPTION
`http://localhost:5000/fetch/agent/<ip>/table` will return the html table generated for that host if it is valid.

Got `make()` in ws_device.py to work by making `self.snmp_device_file()` in `jm_configuration.py` check for the yaml file in `self.data_directory()` instead of calling `self.snmp_directory` (which checks in `self.data_directory()/snmp`

![screenshot from 2016-08-17 23-48-03](https://cloud.githubusercontent.com/assets/7980284/17762686/7dc2757a-64d8-11e6-87a2-5f95f26720b5.png)
